### PR TITLE
Just use wrap, don't wrap individual instances.

### DIFF
--- a/index.js
+++ b/index.js
@@ -4,42 +4,21 @@
  */
 
 var thunkify = require('thunkify');
-var assert = require('assert');
-var aws = require('aws-sdk');
 
 /**
  * Expose `Client`.
  */
 
-module.exports = Client;
-
-/**
- * AWS client.
- *
- * @param {Object} [opts]
- * @api public
- */
-
-function Client(opts) {
-  if (!(this instanceof Client)) return new Client(opts);
-
-  // global?
-  aws.config.update(opts);
-
-  // wayyyy more to support...
-  this.ec2 = new aws.EC2;
-  wrap(this.ec2);
-}
-
 /**
  * Wrap `obj` methods.
  */
 
-function wrap(obj) {
+module.exports = function wrap(obj) {
   Object.keys(obj.__proto__).forEach(function(key){
     var val = obj.__proto__[key];
     if ('constructor' == val) return;
     if ('function' != typeof val) return;
     obj[key] = thunkify(obj[key]);
   });
+  return obj;
 }

--- a/test/index.js
+++ b/test/index.js
@@ -1,6 +1,7 @@
 
 var read = require('fs').readFileSync;
-var AWS = require('..');
+var AWS = require('aws-sdk');
+var coAWS = require('..');
 var co = require('co');
 
 // make tests that other people
@@ -8,17 +9,19 @@ var co = require('co');
 
 var conf = require(process.env.HOME + '/.ec2/segment.json');
 
-var aws = AWS({
+AWS.config.update({
   accessKeyId: conf.key,
   secretAccessKey: conf.secret,
   sslEnabled: true,
   region: 'us-west-2'
 });
 
-describe('ec2', function(){
+var ec2 = coAWS(new AWS.ec2()); // could also pass in, etc.: new AWS.S3()
+
+describe('wrap', function(){
   it('should be wrapped', function(done){
     co(function *(){
-      var res = yield aws.ec2.describeInstances();
+      var res = yield ec2.describeInstances();
       res.should.have.property('Reservations');
     })(done);
   })


### PR DESCRIPTION
By exporting `wrap()`, we can just handle passing in our own instance of whatever AWS service we are trying to use. I tried this with S3 and it works.
